### PR TITLE
fix buffer overflow

### DIFF
--- a/common.c
+++ b/common.c
@@ -173,8 +173,8 @@ void * handle_client(void *s){
                            set_pixel(x, y, r, g, b, a);
                         }
                         else if((x >= 0 && x <= PIXEL_WIDTH) && (y >= 0 && y <= PIXEL_HEIGHT)){
-                           char colorout[20];
-                           sprintf(colorout, "PX %d %d %06x\n",x,y, pixels[y * PIXEL_WIDTH + x] & 0xffffff);
+                           char colorout[30];
+                           snprintf(colorout, sizeof(colorout), "PX %d %d %06x\n",x,y, pixels[y * PIXEL_WIDTH + x] & 0xffffff);
                            send(sock, colorout, sizeof(colorout) - 1, MSG_DONTWAIT | MSG_NOSIGNAL);
                         }
                      }


### PR DESCRIPTION
I noticed the wall to crash on my 1920x1080 system. The new buffer size should be big enough™ and if it is not enough the use of snprintf will prevent the overflow.
