### PR TITLE
macos support and use atomic_flag instead of atomic_bool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,15 @@ CFLAGS_PI = -c -O3 -march=native -DUSE_OPENGL -DUSE_EGL -DIS_RPI -DSTANDALONE -D
 # main_pi.o: main_pi.c
 	# $(CC) $(CFLAGS_PI) $< -o $@
 
-
-
-LDFLAGS_SDL = `pkg-config --libs sdl2` -lm -ldl -lGL -lpthread -O3 -flto -fomit-frame-pointer
+LDFLAGS_SDL = `pkg-config --libs sdl2` -lm -ldl -lpthread -O3 -flto -fomit-frame-pointer
 CFLAGS_SDL = -Wall -Wextra -Werror -pedantic -std=c11 -c `pkg-config --cflags sdl2` -O3 -flto -march=native -fomit-frame-pointer
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+    CFLAGS_SDL += -framework OpenGL
+else
+	CFLAGS_SDL += -lGL
+endif
 
 # sdl: $(EXE_SDL)
 all: $(EXE_SDL)

--- a/server.c
+++ b/server.c
@@ -22,7 +22,7 @@ typedef struct
 {
 	server_t *server;
 	int socket;
-	atomic_bool lock;
+	atomic_flag lock;
 
 	struct timespec last_msg_time;
 


### PR DESCRIPTION
C11 `atomic_flag_test_and_set` and `atomic_flag_clear` only work with `atomic_bool` on `gcc` due to an implementation detail. This change is needed for compliance and to compile with clang.

I added a check in the makefile to deal with the linker flags being different on those platforms.