### PR TITLE
Print listening TCP port on console.

### DIFF
--- a/server.c
+++ b/server.c
@@ -179,9 +179,9 @@ static void *server_listen_thread(void *param)
 	addr_len = sizeof(addr);
 	struct timeval tv;
 
-	printf("Starting Server...\n");
-
 	server_t *server = (server_t*)param;
+
+	printf("Starting Server on port %d...\n", server->port);
 	server->socket = socket(PF_INET, SOCK_STREAM, 0);
 
 	tv.tv_sec = server->timeout;


### PR DESCRIPTION
This explicitly prints on the console which port is used for the server socket. 